### PR TITLE
Add spread type members

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -313,6 +313,13 @@ type CallableTypeMember interface {
 	Result() Element
 }
 
+// SpreadTypeMember is a spread of another type into a type literal
+type SpreadTypeMember interface {
+	Element
+	Reference() Element
+	IsSpreadTypeMember() bool
+}
+
 // SequenceType transforms Elements() type reference into a sequence
 type SequenceType interface {
 	Element
@@ -486,6 +493,7 @@ type Builder interface {
 	TypeLiteralConstant(name Name, value Element) TypeLiteralConstant
 	TypeLiteralMember(name Name, typ Element) TypeLiteralMember
 	CallableTypeMember(parameters []Element, result Element) CallableTypeMember
+	SpreadTypeMember(reference Element) SpreadTypeMember
 	SequenceType(elements Element) SequenceType
 	OptionalType(element Element) OptionalType
 	VocabularyLiteral(members []Element) VocabularyLiteral
@@ -1511,6 +1519,27 @@ func (c *callableTypeMemberImpl) String() string {
 
 func (b *builderImpl) CallableTypeMember(parameters []Element, result Element) CallableTypeMember {
 	return &callableTypeMemberImpl{Location: b.Loc(), parameters: parameters, result: result}
+}
+
+type spreadTypeMemberImpl struct {
+	Location
+	reference Element
+}
+
+func (m *spreadTypeMemberImpl) Reference() Element {
+	return m.reference
+}
+
+func (m *spreadTypeMemberImpl) IsSpreadTypeMember() bool {
+	return true
+}
+
+func (m *spreadTypeMemberImpl) String() string {
+	return fmt.Sprintf("SpreadTypeMember(%s, reference: %s)", m.Location, s(m.reference))
+}
+
+func (b *builderImpl) SpreadTypeMember(reference Element) SpreadTypeMember {
+	return &spreadTypeMemberImpl{Location: b.Loc(), reference: reference}
 }
 
 type sequenceTypeImpl struct {

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -272,6 +272,12 @@ var _ = Describe("ast", func() {
 			Expect(m.Result()).To(BeNil())
 			Expect(s(m)).To(Equal("CallableTypeMember(Location(0-1), parameters: [], result: nil)"))
 		})
+		It("SpreadTypeMember", func() {
+			m := b.SpreadTypeMember(nil)
+			Expect(m.Reference()).To(BeNil())
+			Expect(m.IsSpreadTypeMember()).To(BeTrue())
+			Expect(s(m)).To(Equal("SpreadTypeMember(Location(0-1), reference: nil)"))
+		})
 		It("SequenceType", func() {
 			n := b.SequenceType(nil)
 			Expect(n.Elements()).To(BeNil())

--- a/binder/modulefiles.go
+++ b/binder/modulefiles.go
@@ -77,13 +77,13 @@ func (s *filesScope) populate(fileName string, reader func(fileName string) (io.
 		s.files[name] = &fileModule{name: name, fileName: fileName, reader: reader}
 		return nil
 	}
-    scopeName := dir[0]
-    scope, ok := s.scopes[scopeName]
-    if !ok {
-        scope = newFilesScope()
-        s.scopes[scopeName] = scope
-    }
-     return scope.populate(fileName, reader, dir[1:], name)
+	scopeName := dir[0]
+	scope, ok := s.scopes[scopeName]
+	if !ok {
+		scope = newFilesScope()
+		s.scopes[scopeName] = scope
+	}
+	return scope.populate(fileName, reader, dir[1:], name)
 }
 
 func splitName(fileName string) []string {

--- a/binder/modules.go
+++ b/binder/modules.go
@@ -6,13 +6,13 @@ import (
 
 // ModuleSource is a source file for a module
 type ModuleSource interface {
-    // Name is the name the module that appears in the scope
+	// Name is the name the module that appears in the scope
 	Name() string
 
-    // FileName is the file name use in  error messages
+	// FileName is the file name use in  error messages
 	FileName() string
 
-    // NewReader create a reader for the source
+	// NewReader create a reader for the source
 	NewReader() (io.Reader, error)
 }
 
@@ -23,10 +23,10 @@ func NewModuleSource(name string, fileName string, readFactory func() (io.Reader
 
 // ModuleSourceScope is a scope for finding module sources
 type ModuleSourceScope interface {
-    // FindSocpe finds a subscope of a module scope
+	// FindSocpe finds a subscope of a module scope
 	FindScope(name string) (ModuleSourceScope, error)
 
-    // Find a source module in a scope 
+	// Find a source module in a scope
 	Find(name string) (ModuleSource, error)
 }
 

--- a/builtins/Dyego0_wasm.dg
+++ b/builtins/Dyego0_wasm.dg
@@ -1,6 +1,6 @@
 //...Wasm
 
-...<|
+let Operators = <|
   postfix operator (`++`, `--`, `?.`, `?`) right,
   prefix operator (`+`, `-`, `--`, `++`) right,
   infix operator (`as`, `as?`) left,
@@ -153,5 +153,16 @@ let Double = <
   `!=` = {! other: Double -> inst.f64.ne !}: Boolean
   Min = {! other: Double -> inst.f64.min !}: Double
   Max = {! other: Double -> inst.f64.max !}: Double
+>
+
+<
+  ...Operators
+  Operators = Operators
+  Boolean = Boolean
+  Byte = Byte
+  Double = Double
+  Float = Float
+  Int = Int
+  Long = Long
 >
 

--- a/builtins/Wasm_wasm.dg
+++ b/builtins/Wasm_wasm.dg
@@ -233,3 +233,8 @@ let inst = <
   >
 >
 
+<
+  valtype = valtype
+  inst = inst
+  limits = limits
+>

--- a/examples/Simple.dg
+++ b/examples/Simple.dg
@@ -1,4 +1,4 @@
-...dyego
+...Dyego0
 
 let Vector = <
   x: Double

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -995,6 +995,7 @@ func TestErrors(t *testing.T) {
 	dyegoVocabulary := parseVocabulary(dyego0VocabularySource)
 	scope := newVocabularyScope()
 	scope.members["dyego"] = dyegoVocabulary
+	scope.members["Dyego0"] = dyegoVocabulary
 	defaultScope = scope
 
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Spread type members spread the another type into the current type
allowing expressing subtypes.

Also standardized on returning type literals as a module export.