### PR TITLE
Add a locatable error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,31 @@
+package errors
+
+import (
+	"dyego0/location"
+	"fmt"
+)
+
+// Error is an error that is associated with a Pos range
+type Error interface {
+	error
+	location.Locatable
+}
+
+// New returns a new formatted error message for the given locatable
+func New(loc location.Locatable, message string, args ...interface{}) Error {
+	return NewAt(loc.Start(), loc.End(), message, args...)
+}
+
+// NewAt returns a new formatted error located at start and ending at end
+func NewAt(start location.Pos, end location.Pos, message string, args ...interface{}) Error {
+	return &errorImpl{Location: location.NewLocation(start, end), message: fmt.Sprintf(message, args...)}
+}
+
+type errorImpl struct {
+	location.Location
+	message string
+}
+
+func (e *errorImpl) Error() string {
+	return e.message
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,28 @@
+package errors_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"dyego0/errors"
+	"dyego0/location"
+)
+
+var _ = Describe("errors", func() {
+	It("can create a new error using NewAt", func() {
+		err := errors.NewAt(location.Pos(1), location.Pos(10), "Message")
+		Expect(err.Error()).To(Equal("Message"))
+	})
+	It("can create a new error using New", func() {
+		l := location.NewLocation(location.Pos(1), location.Pos(10))
+		err := errors.New(l, "Message %d %d", 1, 2)
+		Expect(err.Error()).To(Equal("Message 1 2"))
+	})
+})
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ast Suite")
+}


### PR DESCRIPTION
Created an alternative to ast.Error that is also
and golang error that can be located to a file.