### PR TITLE
Convert to using dyego0 errors

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -323,15 +323,7 @@ var _ = Describe("ast", func() {
 		})
 		It("Error", func() {
 			l := b.Error("message")
-			Expect(l.Message()).To(Equal("message"))
-			Expect(s(l)).To(Equal("Error(Location(0-1), message: message)"))
-		})
-		It("DirectError", func() {
-			l := b.DirectError(location.Pos(1), location.Pos(2), "message")
-			Expect(l.Message()).To(Equal("message"))
-			Expect(l.Start()).To(Equal(location.Pos(1)))
-			Expect(l.End()).To(Equal(location.Pos(2)))
-			Expect(s(l)).To(Equal("Error(Location(1-2), message: message)"))
+			Expect(l.Error()).To(Equal("message"))
 		})
 	})
 	Describe("location", func() {

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"dyego0/assert"
+	"dyego0/errors"
 )
 
 // Visitor is an AST visitor
@@ -117,7 +118,7 @@ func WalkChildren(element Element, visitor Visitor) bool {
 			return Walk(e.Name(), visitor)
 		case VocabularyEmbedding:
 			return walkNames(e.Name(), visitor)
-		case Error:
+		case errors.Error:
 			return true
 		default:
 			assert.Fail("Unknown element %#v", element)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,7 @@ import (
 
 	"dyego0/assert"
 	"dyego0/ast"
+	"dyego0/errors"
 	"dyego0/location"
 	"dyego0/scanner"
 	"dyego0/tokens"
@@ -12,7 +13,7 @@ import (
 
 // Parser parses text and returns an ast element
 type Parser interface {
-	Errors() []ast.Error
+	Errors() []errors.Error
 	Parse() ast.Element
 }
 
@@ -27,7 +28,7 @@ type parser struct {
 	scope             vocabularyScope
 	vocabulary        vocabulary
 	embeddingContext  *vocabularyEmbeddingContext
-	errors            []ast.Error
+	errors            []errors.Error
 }
 
 type separatorState int
@@ -74,12 +75,12 @@ func (p *parser) Parse() ast.Element {
 	return expr
 }
 
-func (p *parser) Errors() []ast.Error {
+func (p *parser) Errors() []errors.Error {
 	return p.errors
 }
 
-func (p *parser) report(msg string, args ...interface{}) ast.Error {
-	err := p.builder.Error(fmt.Sprintf(msg, args...))
+func (p *parser) report(msg string, args ...interface{}) errors.Error {
+	err := p.builder.Error(msg, args...)
 	errors := p.errors
 	l := len(errors)
 	if l == 0 || errors[l-1].Start() != err.Start() {
@@ -89,7 +90,7 @@ func (p *parser) report(msg string, args ...interface{}) ast.Error {
 }
 
 func (p *parser) reportElement(element ast.Element, msg string, args ...interface{}) ast.Element {
-	err := p.builder.DirectError(element.Start(), element.End(), fmt.Sprintf(msg, args...))
+	err := errors.New(element, msg, args...)
 	p.errors = append(p.errors, err)
 	return err
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -11,6 +11,7 @@ import (
 
 	"dyego0/assert"
 	"dyego0/ast"
+	"dyego0/errors"
 	"dyego0/location"
 	"dyego0/scanner"
 )
@@ -909,7 +910,7 @@ func lineLenOf(lineMap []int, line int) int {
 	return lineMap[line] - lineMap[line-1]
 }
 
-func printErrors(errors []ast.Error, source string) {
+func printErrors(errors []errors.Error, source string) {
 	if errors != nil {
 		lineMap := lineMapOf(source)
 		for _, err := range errors {
@@ -921,7 +922,7 @@ func printErrors(errors []ast.Error, source string) {
 			if lineLength-col < errorLen {
 				errorLen = lineLength - col
 			}
-			println(fmt.Sprintf("%d:%d: %s", line, col, err.Message()))
+			println(fmt.Sprintf("%d:%d: %s", line, col, err.Error()))
 			if line < len(lineMap) {
 				println(source[lineMap[line-1] : lineMap[line]-1])
 			}
@@ -959,7 +960,7 @@ func expectErrors(text string, errors ...string) {
 loop:
 	for _, message := range errors {
 		for _, err := range p.Errors() {
-			if strings.Contains(err.Message(), message) {
+			if strings.Contains(err.Error(), message) {
 				continue loop
 			}
 		}


### PR DESCRIPTION
Remove the error node from the AST in favor of the error
in the errors packages.

This allows error to be generally useful and not require
an ast reference.